### PR TITLE
Use polyfill to statically guarantee `push_op` closure has no environment

### DIFF
--- a/src/vm/tape.rs
+++ b/src/vm/tape.rs
@@ -50,6 +50,14 @@ impl Tape {
         //     }
         // }
 
+        /// ```compile_fail
+        /// use yurt::vm::Tape;
+        /// let mut tape = Tape::default();
+        /// let i = 0;
+        /// tape.push_op((), |(), _, _, _| {
+        ///     let _ = &i;
+        /// });
+        /// ```
         trait NoCapture: Sized {
             const ASSERT: () = assert!(core::mem::size_of::<Self>() == 0, "Can only perform operations that have no environment");
         }

--- a/src/vm/tape.rs
+++ b/src/vm/tape.rs
@@ -50,7 +50,14 @@ impl Tape {
         //     }
         // }
 
-        assert_eq!(core::mem::size_of::<F>(), 0, "Operation functions are not permitted to have captures");
+        trait NoCapture: Sized {
+            const ASSERT: () = assert!(core::mem::size_of::<Self>() == 0, "Can only perform operations that have no environment");
+        }
+
+        impl<F> NoCapture for F {}
+
+        #[allow(clippy::let_unit_value)]
+        let _ = <F as NoCapture>::ASSERT;
 
         self.push(perform::<A, F> as TapeFn);
         args.push(self);


### PR DESCRIPTION
Uses [the same method as the `extern_c` crate](https://docs.rs/extern-c/latest/src/extern_c/helpers.rs.html#9-13) to assert that the closure given to `Tape::push_op` is zero-sized without needing a `const` block.